### PR TITLE
https://github.com/AdguardTeam/PopupBlocker/issues/13#issuecomment-322715286

### DIFF
--- a/src/ui/show-alert.ts
+++ b/src/ui/show-alert.ts
@@ -83,6 +83,8 @@ class Alert implements AlertIntf {
         let width = showCollapsed ? STYLE_CONST.collapsed_width : STYLE_CONST.width;
         iframe.style['height'] = height + px;
         iframe.style['width'] = width + px;
+        // Enable sandboxing
+        iframe.setAttribute('sandbox', 'allow-same-origin');
 
         this.element = iframe;
         this.collapsed = showCollapsed;
@@ -97,10 +99,12 @@ class Alert implements AlertIntf {
     collapse() {
         if (this.collapsed) { return; }
         this.element.style['height'] = STYLE_CONST.collapsed_height + px;
+        this.element.style['width'] = STYLE_CONST.collapsed_width + px;
         let root = this.element.contentDocument[getElementsByClassName]('popup')[0];
         root.classList.add('popup--min');
         this.collapsed = true;
         this.height = STYLE_CONST.collapsed_height;
+        // Since its state was changed, update its lastUpdate property.
         this.lastUpdate = new Date().getTime();
     }
     destroy() {

--- a/src/ui/show-alert.ts
+++ b/src/ui/show-alert.ts
@@ -26,6 +26,7 @@ const initialAlertFrameStyle = {
     "top": STYLE_CONST.top_offset + px,
     "border": "none",
     "opacity": "0",
+    "z-index": String(-1 - (1 << 31)),
     "transition": "opacity 500ms, top 500ms",
     "transitionTimingFunction": "cubic-bezier(0.86, 0, 0.07, 1), cubic-bezier(0.86, 0, 0.07, 1)"
 };


### PR DESCRIPTION
When a user hovers the mouse over any of alerts,

 1. All timers are cleared, so as to prevent ui change during user interaction;
 1. When the mouse is moved out of alerts:
   - It resumes all timers as if there was no pause;
   - If a pause was long enough so that ANY of timer's callback should have been called, call the oldest callback immediately, and then schedules other callbacks so that relative fire time differences are unchanged.